### PR TITLE
dockerで環境構築

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+
+local/.env

--- a/local/.env.example
+++ b/local/.env.example
@@ -1,0 +1,2 @@
+# 自分の環境のプロジェクトディレクトリを指定する
+PROJECT_FILE_PATH=/Users/h_hayashi/Projects/laravel_elasticsearch

--- a/local/Dockerfile
+++ b/local/Dockerfile
@@ -1,0 +1,45 @@
+FROM amazonlinux:2.0.20190228
+
+# RUN
+# PHPとPHP-FPMのインストール
+RUN amazon-linux-extras install php7.3
+
+# 依存ライブラリのインストール
+
+
+RUN yum update -y
+RUN yum install -y git
+RUN yum install -y gmp-devel
+RUN yum install -y libmcrypt
+RUN yum install -y libpng-devel
+RUN yum install -y libxml2-devel
+RUN yum install -y libmcrypt-devel
+RUN yum install -y libmemcached-devel
+RUN yum install -y openssh-client make grep autoconf gcc libc-dev zlib-dev cyrus-sasl-dev libmemcached-dev zlib-dev
+
+# extensionのインストール
+RUN yum install -y php-gmp
+RUN yum install -y php-xml
+RUN yum install -y php-mbstring
+RUN yum install -y php-pdo
+RUN yum install -y php-tokenizer
+RUN yum install -y php-dom
+RUN yum install -y php-pdo_mysql
+RUN yum install -y php-pear
+RUN yum install -y php-devel
+RUN yum install -y php-gd
+RUN yum install -y php-zip
+
+RUN pecl install memcached-3.1.3
+RUN echo extension=memcached.so >> /etc/php.ini
+
+
+# アプリケーションをデプロイ
+# /projects/laravel/jobkul_client
+# に接続されているはず
+
+# composerのインストール
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/bin --filename=composer
+
+RUN curl -sL https://rpm.nodesource.com/setup_10.x | bash
+RUN yum install -y nodejs

--- a/local/docker-compose.yml
+++ b/local/docker-compose.yml
@@ -3,6 +3,8 @@ version: '3'
 volumes:
   mysql-db:
     driver: local
+  es-data:
+    driver: local
 
 services:
   mysql:
@@ -39,3 +41,20 @@ services:
       - 9000:9000
     links:
       - mysql
+
+
+  elasticsearch:
+    image: elasticsearch:7.3.2
+    volumes:
+      - es-data:/usr/share/elasticsearch/data
+    environment:
+      - discovery.type=single-node
+      - cluster.name=docker-cluster
+      - bootstrap.memory_lock=true
+      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
+    ports:
+      - "9200:9200"

--- a/local/docker-compose.yml
+++ b/local/docker-compose.yml
@@ -44,7 +44,7 @@ services:
 
 
   elasticsearch:
-    image: elasticsearch:7.3.2
+    build: ./elasticsearch
     volumes:
       - es-data:/usr/share/elasticsearch/data
     environment:

--- a/local/docker-compose.yml
+++ b/local/docker-compose.yml
@@ -1,0 +1,41 @@
+version: '3'
+
+volumes:
+  mysql-db:
+    driver: local
+
+services:
+  mysql:
+    image: mysql:5.6
+    volumes:
+      - mysql-db:/var/lib/mysql
+      - ./mysql/init:/docker-entrypoint-initdb.d
+      - ./mysql/etc:/etc/mysql/conf.d
+    ports:
+      - 3308:3306
+    environment:
+      - MYSQL_DATABASE=laravel_elasticsearch
+      - MYSQL_ROOT_PASSWORD=password01
+
+  ## composer installs
+  composer:
+    build: ./
+    command: composer install -d /projects/laravel/laravel_elasticsearch/server
+    volumes:
+      - ${PROJECT_FILE_PATH}:/projects/laravel/laravel_elasticsearch:cached
+    links:
+      - mysql
+
+  ## app services
+  laravel:
+    build: ./
+    command: php /projects/laravel/laravel_elasticsearch/server/artisan serve --host 0.0.0.0 --port=9000
+    volumes:
+      - ${PROJECT_FILE_PATH}:/projects/laravel/laravel_elasticsearch:cached
+    depends_on:
+      - composer
+    restart: always
+    ports:
+      - 9000:9000
+    links:
+      - mysql

--- a/local/elasticsearch/Dockerfile
+++ b/local/elasticsearch/Dockerfile
@@ -1,0 +1,4 @@
+FROM docker.elastic.co/elasticsearch/elasticsearch:7.3.2
+
+# 日本語を全文検索するためのpulgin
+RUN elasticsearch-plugin install analysis-kuromoji


### PR DESCRIPTION
# なにこれ
タイトルの通り。
Laravel, MySQL, ElasticSearchをdockerで立ち上げる


# Elasticsearchをdockerで立ち上げる参考
https://www.yoheim.net/blog.php?q=20190201

# ElasticSearchを立ち上げてすぐにコンテナが落ちる問題
```
elasticsearch_1  | {"type": "server", "timestamp": "2019-09-22T03:27:53,917+0000", "level": "INFO", "component": "o.e.x.m.p.NativeController", "cluster.name": "docker-cluster", "node.name": "37092a04af2c",  "message": "Native controller process has stopped - no new native processes can be started"  }
local_elasticsearch_1 exited with code 78
```

ElasticSearch7では設定parameterが増えたらしい。

なので、以下で対応
https://www.elastic.co/guide/en/elasticsearch/reference/current/docker.html
